### PR TITLE
Add trailing comma rule and prepare release

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ This package includes the shareable ESLint configuration used by Fewlines typesc
 
 Extends `eslint:recommended`, `@typescript-eslint/eslint-recommended`, `@typescript-eslint/recommended`,
 
+:warning: As this plugin wants to use a minimalist configuration, it relies on using `prettier` via `ESLint` which mean you
+could have to configure your editor.
+
+See here for VSCode: https://github.com/prettier/prettier-vscode#vs-code-eslint-and-tslint-integration
+
 ## Usage
 
 ```shell
@@ -13,7 +18,6 @@ yarn add -D @fewlines/eslint-config-fewlines-ts eslint \
 eslint-config-prettier eslint-plugin-prettier prettier \
 @typecript-eslint/eslint-plugin @typescript-eslint/parser
 ```
-
 
 Then add these line to your `package.json`:
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This package includes the shareable ESLint configuration used by Fewlines typesc
 
 Extends `eslint:recommended`, `@typescript-eslint/eslint-recommended`, `@typescript-eslint/recommended`,
 
-:warning: As this plugin wants to use a minimalist configuration, it relies on using `prettier` via `ESLint` which mean you
+:warning: As this plugin wants to use a minimalist configuration, it relies on using `prettier` via `ESLint` which means you
 could have to configure your editor.
 
 See here for VSCode: https://github.com/prettier/prettier-vscode#vs-code-eslint-and-tslint-integration
@@ -19,7 +19,7 @@ eslint-config-prettier eslint-plugin-prettier prettier \
 @typecript-eslint/eslint-plugin @typescript-eslint/parser
 ```
 
-Then add these line to your `package.json`:
+Then add these lines to your `package.json`:
 
 ```json
 "eslintConfig": {

--- a/index.js
+++ b/index.js
@@ -12,7 +12,8 @@ module.exports = {
   parser: "@typescript-eslint/parser",
   plugins: ["@typescript-eslint", "prettier"],
   rules: {
-    "prettier/prettier": "error",
-    "@typescript-eslint/camelcase": "off"
+    "prettier/prettier": ["error", { "trailingCommas": "all" }],
+    "@typescript-eslint/camelcase": "off",
+    "comma-dangle": ["error", "always-multiline"]
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fewlines/eslint-config-fewlines-ts",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "Shareable ESLint configuration used by Fewlines for TS projects",
   "main": "index.js",
   "author": "Fewlines",


### PR DESCRIPTION
## Detailed Description

This PR adds a warning about using ESLint instead of Prettier as a formatter tool as ESLint has all the prettier rules (with `eslint-config-prettier`) and can do more.

It also changes the version as I think the project is ready for release 🕊 

## Related Story

[ch969]